### PR TITLE
added artist images to the get Random Artist button

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,4 +84,7 @@ dependencies {
     testImplementation("androidx.test.ext:junit-ktx:1.1.5")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.1")
     testImplementation("androidx.room:room-testing:$room_version")
+
+    //images
+    implementation("io.coil-kt:coil-compose:2.6.0")
 }

--- a/app/src/main/java/com/example/project01group03/HomeScreen.kt
+++ b/app/src/main/java/com/example/project01group03/HomeScreen.kt
@@ -4,16 +4,21 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
 import com.example.project01group03.API.RetrofitClient
 import kotlinx.coroutines.launch
 
@@ -28,26 +33,49 @@ fun HomeScreen(onLogout: () -> Unit) {
     //remember keeps the value from being reset
     //without it, it breakes :(
     var artistName by remember { mutableStateOf("No artist loaded") }
-    Column(modifier = Modifier.padding(16.dp)) {
+    //Column(modifier = Modifier.padding(16.dp)) {
+    var artistImageUrl by remember { mutableStateOf<String?>(null) }
+    Column(modifier = Modifier.padding(16.dp), horizontalAlignment = Alignment.CenterHorizontally) {
         //displays the random artist
         Text(text = "Artist: $artistName")
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Show the artist image (if available)
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(artistImageUrl)
+                .crossfade(true)
+                .build(),
+            contentDescription = "Artist image",
+            modifier = Modifier.size(220.dp)
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
         Button(onClick = {
             //starts the task for network call to api
             scope.launch {
                 //calls discog api and gets random artist from pages 1-100 for now just to test
-                val response = RetrofitClient.discogsApiService.searchArtists(query = "",
-                    page = (1..100).random()//random number for artist page
+                val response = RetrofitClient.discogsApiService.searchArtists(
+                    query = "",
+                    page = (1..100).random()
                 )
-                artistName = response.results.firstOrNull()?.title ?: "No artist found"//displays no artist found if nothing returns
+
+                val first = response.results.firstOrNull()
+                artistName = first?.title ?: "No artist found"
+
+                // Discogs search results typically expose an image URL like `cover_image`.
+                // If your model uses a different property name, update this line to match.
+                artistImageUrl = first?.coverImage
             }
         }) {
             Text("Get Random Artist")
         }
-    Column(modifier = Modifier.padding(16.dp)) {
+
+        Spacer(modifier = Modifier.height(24.dp))
         Text(text = "Welcome to the Home Screen!")
         Spacer(modifier = Modifier.height(16.dp))
         Button(onClick = onLogout) {
             Text("Logout")
         }
     }
-}}
+}


### PR DESCRIPTION
I added the coil library (a library built for handling images) to the build.gradle.kts so that we can load images off the UI thread, to help fetch the images, and display them. 

I also added some imports to the HomeScreen class. 

-  coil.compose.AsyncImage: what actually displays an image from a URL in Compose.
- coil.request.ImageRequest: lets you configure how an image is loaded. (animation, caching options, resizing)
- androidx.compose.ui.platform.LocalContext: gives access to android context inside a composable to access system resources, manage image caching, handle lifecycles safely.
- androidx.compose.foundation.layout.size: adds Modifier.size() which lets one set the height and width of a composable (in this case the image)
- import androidx.compose.ui.Alignment: provides alignment constants to keep the image centered in the column

Apart from that, I didn't change the HomeScreen file too much, apart from adding the image and spacers.